### PR TITLE
Fix product description new lines

### DIFF
--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -298,7 +298,7 @@ const ProductDetail: React.FC = () => {
             {/* Description */}
             <div>
               <h3 className="text-lg font-semibold text-gray-900 mb-2">Description</h3>
-              <p className="text-gray-600 leading-relaxed">
+              <p className="text-gray-600 leading-relaxed whitespace-pre-line">
                 {product.description}
               </p>
             </div>


### PR DESCRIPTION
Add `whitespace-pre-line` to product description to render newlines.

The product description on the detail page was not displaying newlines (`\n`), causing the text to appear as a single collapsed paragraph. Adding `whitespace-pre-line` ensures that newline characters are converted into visible line breaks, improving readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-196e1c89-5281-47fe-b5d3-47e36431458a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-196e1c89-5281-47fe-b5d3-47e36431458a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

